### PR TITLE
Fix nil pointer exception. Avoid spurious local time adjustment message.

### DIFF
--- a/coinbase/datastore.go
+++ b/coinbase/datastore.go
@@ -313,7 +313,7 @@ func (ds *Datastore) saveOrdersLocked(ctx context.Context, orders []*internal.Or
 		ds.recentlySaved = append(ds.recentlySaved, vs...)
 	}
 	slices.SortFunc(ds.recentlySaved, compareLastFillTime)
-	slices.CompactFunc(ds.recentlySaved, equalLastFillTime)
+	ds.recentlySaved = slices.CompactFunc(ds.recentlySaved, equalLastFillTime)
 	return nil
 }
 

--- a/coinbase/internal/client.go
+++ b/coinbase/internal/client.go
@@ -89,7 +89,7 @@ func (c *Client) Close() error {
 
 func (c *Client) goFindTimeAdjustment(ctx context.Context) {
 	for ctxutil.Sleep(ctx, c.opts.SyncTimeInterval); ctx.Err() == nil; ctxutil.Sleep(ctx, c.opts.SyncTimeInterval) {
-		if diff, err := findTimeAdjustment(ctx, c.opts.MaxFetchTimeLatency); err == nil {
+		if diff, err := findTimeAdjustment(ctx, c.opts.MaxFetchTimeLatency); err == nil && diff != 0 {
 			log.Printf("local time needs to be adjusted by -%s to match the coinbase server time", diff)
 			c.timeAdjustment.Store(int64(diff))
 		}


### PR DESCRIPTION
Fixes periodic nil pointer issue caused by using old slice that was compacted. Only occurs in go 1.22 and newer as compacted values are nil-ed. 